### PR TITLE
Custom error를 통한 error handling

### DIFF
--- a/os/common/javascript/typescript/node-js/base-init/src/errors/errorGenerator.ts
+++ b/os/common/javascript/typescript/node-js/base-init/src/errors/errorGenerator.ts
@@ -1,0 +1,26 @@
+type HTTP_STATUS_MESSAGE = {[key:number]:string}
+const DEFAULT_HTTP_STATUS_MESSAGES : HTTP_STATUS_MESSAGE = {
+    400: 'Bad Requests', // client에서 request 요청 시 누락 또는 잘못된 데이터 전송 및 요청
+    401: 'Unauthorized',
+    403: 'Forbidden',
+    404: 'Not Found',
+    405: 'Wrong method', // GET인데 POST로 요청하거나 .. 
+    409: 'duplicate',
+    500: 'Internal Server Error', // Server 로직 수행 중 터짐
+    503: 'Temporary Unavailable',
+};
+
+//interface 이용해 Error 객체에 statusCode key 추가
+export interface ErrorWithStatusCode extends Error {
+    statusCode? : number
+};
+
+const errorGenerator = ({ msg='', statusCode=500}: { msg?: string, statusCode: number }): void => {
+    //인자로 들어오는 메세지와 상태 코드를 매핑
+    const err: ErrorWithStatusCode = new Error(msg || DEFAULT_HTTP_STATUS_MESSAGES[statusCode]);
+    err.statusCode = statusCode;
+    throw err;
+}
+
+export default errorGenerator;
+

--- a/os/common/javascript/typescript/node-js/base-init/src/errors/generalErrorHandler.ts
+++ b/os/common/javascript/typescript/node-js/base-init/src/errors/generalErrorHandler.ts
@@ -1,0 +1,10 @@
+import { ErrorRequestHandler, Request, Response, NextFunction } from 'express';
+import { ErrorWithStatusCode } from './errorGenerator';
+
+const generalErrorHandler: ErrorRequestHandler = (err: ErrorWithStatusCode, req: Request, res: Response, next: NextFunction) => {
+    const { message, statusCode } = err;
+    //console.error(err);
+    res.status(statusCode || 500).json({ message });
+}
+
+export default generalErrorHandler;

--- a/os/common/javascript/typescript/node-js/base-init/src/loaders/express.ts
+++ b/os/common/javascript/typescript/node-js/base-init/src/loaders/express.ts
@@ -1,5 +1,6 @@
 import express, { Request, Response, NextFunction }from 'express';
 import routes from '../routes';
+import generalErrorHandler from '../errors/generalErrorHandler';
 
 export default async ({ app }: { app: express.Application }) => {
     require('dotenv').config();
@@ -10,6 +11,7 @@ export default async ({ app }: { app: express.Application }) => {
     app.use(require('helmet')())
 
     app.use(routes)
+    app.use(generalErrorHandler)
 
     // import type { ErrorRequestHandler } from "express";
     // export type ErrorRequestHandler = (err: any, req: Request, res: Response, next:NextFunction


### PR DESCRIPTION
# New Feature 🖐

custom error handler 사용

## 세부 사항
- errors/errorGenerator.ts
  - ErrorWithStatusCode interface 정의
    -  extends Error
  - 해당 파일에서 미리 준비된 statusCode:message json파일 ([key:number] : string)를 바탕으로 statusCode에 따른 msg를 매핑
  - 매핑된 정보를 바탕으로 ErrorWithSatusCode type의 error를 return
- errors/generalErrorHandler.ts
  - ErrorWithStatusCode를 통해 event가 발생하면 해당 err를 잡아 json에 넣어 http status와 함께 response 
- loaders/express
  - error handler등록